### PR TITLE
Fix double quotation marks causing error

### DIFF
--- a/+UnitTest/+tokernizer/TokenizeTests.m
+++ b/+UnitTest/+tokernizer/TokenizeTests.m
@@ -1,0 +1,75 @@
+classdef TokenizeTests < matlab.unittest.TestCase
+    %TOKENIZETESTS Tests for tokenize_code
+    
+    methods(Test)
+        function testDoubleQuote(obj)
+            %TESTDOUBLEQUOTE Tests a double quoted string
+            
+            % Input data for the test
+            input_str = '"test"'; % String: "test"
+            
+            % Construct expected output for comparison
+            expected = Token('string', input_str, 1, 1);
+            
+            % Get actual output
+            actual = tokenize_code(input_str);
+            
+            % Compare actual output with expected output
+            obj.verifyEqual(actual, expected);
+        end
+        
+        function testSoloDoubleQuote(obj)
+            %TESTSOLODOUBLEQUOTE Tests a string with only a double quoted
+            
+            % Input data for the test
+            input_str = 'output = "test"'; % String: output = 'test'
+            
+            % Construct expected output for comparison
+            expected(1) = Token('identifier', 'output', 1, 1);
+            expected(2) = Token('space', ' ', 1, 7);
+            expected(3) = Token('punctuation', '=', 1, 8);
+            expected(4) = Token('space', ' ', 1, 9);
+            expected(5) = Token('string', '"test"', 1, 10);
+            
+            % Get actual output
+            actual = tokenize_code(input_str);
+            
+            % Compare actual output with expected output
+            obj.verifyEqual(actual, expected);
+        end
+        
+        function testNestedQuote(obj)
+            %TESTNESTEDQUOTE Tests a double quote inside single quote
+            
+            % Input data for the test
+            input_str = '"let''s go"'; % String: "let's go"
+            
+            % Construct expected output for comparison
+            expected = Token('string', input_str, 1, 1);
+            
+            % Get actual output
+            actual = tokenize_code(input_str);
+            
+            % Compare actual output with expected output
+            obj.verifyEqual(actual, expected);
+        end
+        
+        function testNestedQuote2(obj)
+            %TESTNESTEDQUOTE2 Tests a double quote inside single quote
+            
+            % Input data for the test
+            input_str = '''He said, "hi"'''; % String: 'He said, "hi"'
+            
+            % Construct expected output for comparison
+            expected = Token('string', input_str, 1, 1);
+            
+            % Get actual output
+            actual = tokenize_code(input_str);
+            
+            % Compare actual output with expected output
+            obj.verifyEqual(actual, expected);
+        end
+        
+        %todo: "let's go", 'He said, "hi"'
+    end
+end

--- a/+UnitTest/+tokernizer/TokenizeTests.m
+++ b/+UnitTest/+tokernizer/TokenizeTests.m
@@ -69,7 +69,5 @@ classdef TokenizeTests < matlab.unittest.TestCase
             % Compare actual output with expected output
             obj.verifyEqual(actual, expected);
         end
-        
-        %todo: "let's go", 'He said, "hi"'
     end
 end

--- a/run_unittests.m
+++ b/run_unittests.m
@@ -1,0 +1,28 @@
+function run_unittests()
+    %RUN_UNITTESTS Runs all unit tests
+    
+    import matlab.unittest.TestSuite
+    import matlab.unittest.TestRunner
+    
+    try
+        % Create a test suite
+        suite = ...
+            TestSuite.fromPackage('UnitTest', ...
+            'IncludingSubpackages', true);
+
+        % Run all tests
+        runner = TestRunner.withTextOutput;
+        result = runner.run(suite);
+
+        % Display results
+        disp(table(result));
+        disp(result);
+
+        % Throw an error if any test failed
+        if sum([result(:).Failed]) + sum([result(:).Incomplete]) > 0
+            error('There are failing unittests!')
+        end
+    catch err
+        disp(err.getReport)
+    end
+end

--- a/tokenize_code.m
+++ b/tokenize_code.m
@@ -126,22 +126,30 @@ function tokenlist = tokenize_code(source_code)
         % strings and transpose begin with `'`. The `.'` operator has
         % already been handled above:
         elseif letter == ''''
-            is_first_symbol = false;
-            previous = tokenlist(end);
-            % transpose operator:
-            % To differentiate the start of a string from the transpose
-            % operator, we need to check whether the previous token was a
-            % value or an operator. If a value, `'` means transpose. If an
-            % operator, `'` marks the start of a string.
-            if previous.isEqual('pair', {'}' ']' ')'}) || ...
-               previous.hasType({'identifier' 'number' 'property'})
-                pos = pos + 1;
-                add_token('punctuation', letter);
-            % strings:
-            else
-                string = skip_string();
+            % the first symbol cannot be transpose, so must be string
+            if is_first_symbol
+                string = skip_string('''');
                 add_token('string', string);
+            else
+                previous = tokenlist(end);
+                
+                % transpose operator:
+                % To differentiate the start of a string from the
+                % transpose operator, we need to check whether the
+                % previous token was a value or an operator. If a value,
+                % `'` means transpose. If an operator, `'` marks the start
+                % of a string.
+                if previous.isEqual('pair', {'}' ']' ')'}) || ...
+                   previous.hasType({'identifier' 'number' 'property'})
+                    pos = pos + 1;
+                    add_token('punctuation', letter);
+                % strings:
+                else
+                    string = skip_string('''');
+                    add_token('string', string);
+                end
             end
+            is_first_symbol = false;
         % string that starts with double quotes (")
         elseif letter == '"'
             is_first_symbol = false;

--- a/tokenize_code.m
+++ b/tokenize_code.m
@@ -26,6 +26,7 @@ function tokenlist = tokenize_code(source_code)
     open_pairs = '{[(';
     close_pairs = '}])';
     escapes = '!%';
+    quotes = { '''', '"' };
 
     keywords = check_settings('keywords');
     
@@ -142,6 +143,11 @@ function tokenlist = tokenize_code(source_code)
                 string = skip_string();
                 add_token('string', string);
             end
+        % string that starts with double quotes (")
+        elseif letter == '"'
+            is_first_symbol = false;
+            string = skip_string();
+            add_token('string', string);
         % we don't make any distinction between different kinds of parens:
         elseif any(letter == open_pairs)
             is_first_symbol = false;
@@ -253,11 +259,11 @@ function tokenlist = tokenize_code(source_code)
 
         string_start = pos;
         while true
-            if source_code(pos) ~= '''' || pos == string_start
+            if ~any(strcmp(source_code(pos), quotes)) || pos == string_start
                 pos = pos + 1;
-            elseif length(source_code) > pos && source_code(pos+1) == ''''
+            elseif length(source_code) > pos && any(strcmp(source_code(pos+1), quotes))
                 pos = pos + 2;
-            else % source_code(pos) == ''''
+            else % any(strcmp(source_code(pos), quotes))
                 pos = pos + 1;
                 break;
             end
@@ -301,7 +307,7 @@ function tokenlist = tokenize_code(source_code)
         while pos < length(source_code)
             letter = source_code(pos);
             % commands can contain literal strings:
-            if letter == ''''
+            if any(strcmp(letter, quotes))
                 string_literal = skip_string();
                 add_token('string', string_literal);
             % commands can contain spaces:


### PR DESCRIPTION
When parsing a file containing double quotation marks ("), the tokenizer
would throw an error due to not being able to identify the character.

This error has been fixed by allowing the tokenize_code() function to
treat double quotation marks as strings, using the skip_string()
function.

This fixes bastibe/MatlabCodeAnalyzer#10